### PR TITLE
bgp: fix stack buffer overflow in EVPN parseNlriData

### DIFF
--- a/Server/src/bgp/EVPN.cpp
+++ b/Server/src/bgp/EVPN.cpp
@@ -366,6 +366,7 @@ namespace bgp_msg {
                         len -= 22;
 
                         addr_bytes = tuple.ip_len > 0 ? (tuple.ip_len / 8) : 0;
+                        if (addr_bytes > (int)sizeof(ip_binary)) addr_bytes = sizeof(ip_binary);
 
                         if (tuple.ip_len > 0 and (addr_bytes + data_read) <= data_len) {
                             // IP Address (0, 4, or 16 bytes)
@@ -434,6 +435,7 @@ namespace bgp_msg {
                         len -= 5;
 
                         addr_bytes = tuple.originating_router_ip_len > 0 ? (tuple.originating_router_ip_len / 8) : 0;
+                        if (addr_bytes > (int)sizeof(ip_binary)) addr_bytes = sizeof(ip_binary);
 
                         if (tuple.originating_router_ip_len > 0 and (addr_bytes + data_read) <= data_len) {
 
@@ -470,12 +472,13 @@ namespace bgp_msg {
                         len -= 11;
 
                         addr_bytes = tuple.originating_router_ip_len > 0 ? (tuple.originating_router_ip_len / 8) : 0;
+                        if (addr_bytes > (int)sizeof(ip_binary)) addr_bytes = sizeof(ip_binary);
 
                         if (tuple.originating_router_ip_len > 0 and (addr_bytes + data_read) <= data_len) {
 
                             // Originating Router's IP Address (4 or 16 bytes)
                             bzero(ip_binary, 16);
-                            memcpy(&ip_binary, data_pointer, (int) tuple.originating_router_ip_len / 8);
+                            memcpy(&ip_binary, data_pointer, addr_bytes);
 
                             inet_ntop(tuple.originating_router_ip_len > 32 ? AF_INET6 : AF_INET,
                                       ip_binary, ip_char, sizeof(ip_char));


### PR DESCRIPTION
#### Why I did it

ip_binary is a 16-byte stack buffer in EVPN::parseNlriData. The IP Address Length field read from wire data (1 byte) was divided by 8 to get addr_bytes, which can be up to 31. This value was passed directly to memcpy with no destination-size check, allowing up to 15 bytes of stack overflow. Three parsing paths were affected: type-2 (MAC-IP Advertisement), type-3 (IMET), and type-4 (ES).

#### How I did it

Added a clamp after the addr_bytes computation in all three paths:

    if (addr_bytes > (int)sizeof(ip_binary)) addr_bytes = sizeof(ip_binary);

Also fixed the type-4 path to use the clamped addr_bytes in memcpy instead of the raw unclamped expression it previously used.

#### How to verify it

Build passes: cmake + make with no errors (tested on Ubuntu 24.04, gcc 13). No unit tests exist in this repo.

The same fix has been submitted upstream: https://github.com/SNAS/openbmp/pull/100