### PR TITLE
[bmp] Pipeline and batch redis writes from openbmpd

### DIFF
--- a/Server/src/RedisManager.cpp
+++ b/Server/src/RedisManager.cpp
@@ -9,6 +9,15 @@
 
 #include "RedisManager.h"
 
+/**
+ * Default size of the shared RedisPipeline buffer used for BMP state
+ * writes. Set high enough that a typical BMP UPDATE worth of route
+ * entries fits in a single round-trip, but bounded so that the pipeline
+ * auto-flushes if a producer goes quiet without the message-level
+ * flush hook ever firing.
+ */
+static constexpr size_t BMP_PIPELINE_SIZE = 1024;
+
 
 /*********************************************************************//**
  * Constructor for class
@@ -37,8 +46,13 @@ void RedisManager::Setup(Logger *logPtr) {
 
     stateDb_ =  std::make_shared<swss::DBConnector>(BMP_DB_NAME, 0, false);
     separator_ = swss::SonicDBConfig::getSeparator(BMP_DB_NAME);
-}
 
+    // Build a single shared pipeline backed by the same logical DB. All
+    // per-table buffered Table writers below share this pipeline so that a
+    // flush() sends every queued HSET in a single batch instead of one
+    // round-trip per route entry.
+    pipeline_ = std::make_shared<swss::RedisPipeline>(stateDb_.get(), BMP_PIPELINE_SIZE);
+}
 
 
 /**
@@ -52,6 +66,31 @@ std::string RedisManager::GetKeySeparator() {
 
 
 /**
+ * Lookup-or-create a buffered Table writer for the given table name.
+ *
+ * The Table is constructed with buffered=true and bound to pipeline_, so
+ * each set() call enqueues the underlying HSET on the pipeline rather
+ * than synchronously talking to redis. The actual round-trip happens on
+ * FlushBMPTables() (or when the pipeline buffer fills).
+ *
+ * Returns nullptr if the table is not enabled via CONFIG_DB.
+ */
+swss::Table* RedisManager::GetOrCreateBufferedTable(const std::string& table) {
+    if (enabledTables_.find(table) == enabledTables_.end()) {
+        return nullptr;
+    }
+    auto it = bufferedTables_.find(table);
+    if (it == bufferedTables_.end()) {
+        auto t = std::make_unique<swss::Table>(pipeline_.get(), table, /*buffered=*/true);
+        auto raw = t.get();
+        bufferedTables_.emplace(table, std::move(t));
+        return raw;
+    }
+    return it->second.get();
+}
+
+
+/**
  * WriteBMPTable
  *
  * \param [in] table            Reference to table name
@@ -60,11 +99,11 @@ std::string RedisManager::GetKeySeparator() {
  */
 bool RedisManager::WriteBMPTable(const std::string& table, const std::vector<std::string>& keys, const std::vector<swss::FieldValueTuple> fieldValues) {
 
-    if (enabledTables_.find(table) == enabledTables_.end()) {
+    swss::Table* stateBMPTable = GetOrCreateBufferedTable(table);
+    if (stateBMPTable == nullptr) {
         DEBUG("RedisManager %s is disabled", table.c_str());
         return false;
     }
-    std::unique_ptr<swss::Table> stateBMPTable = std::make_unique<swss::Table>(stateDb_.get(), table);
     std::ostringstream oss;
     for (const auto& key : keys) {
         oss << key << separator_;
@@ -89,8 +128,23 @@ bool RedisManager::RemoveEntityFromBMPTable(const std::vector<std::string>& keys
     for (const auto& key : keys) {
         DEBUG("RedisManager RemoveEntityFromBMPTable key = %s", key.c_str());
     }
+    // Flush any buffered SETs first so that a later DEL on the same key
+    // cannot be reordered before its preceding SET.
+    FlushBMPTables();
     stateDb_->del(keys);
     return true;
+}
+
+
+/**
+ * FlushBMPTables - flush all buffered table writers' pending operations.
+ */
+void RedisManager::FlushBMPTables() {
+    for (auto& kv : bufferedTables_) {
+        if (kv.second) {
+            kv.second->flush();
+        }
+    }
 }
 
 
@@ -100,6 +154,9 @@ bool RedisManager::RemoveEntityFromBMPTable(const std::vector<std::string>& keys
  * \param [in] N/A
  */
 void RedisManager::ExitRedisManager() {
+    // Best-effort: drain anything still buffered so we don't lose state
+    // updates that have already been observed by openbmpd.
+    FlushBMPTables();
     exit_ = true;
 }
 

--- a/Server/src/RedisManager.cpp
+++ b/Server/src/RedisManager.cpp
@@ -44,6 +44,13 @@ void RedisManager::Setup(Logger *logPtr) {
         swss::SonicDBConfig::initialize();
     }
 
+    // Drop any pre-existing buffered Table writers before we replace the
+    // pipeline they reference. Today Setup() is only called once from
+    // MsgBusImpl_redis's constructor, but bufferedTables_ holds raw
+    // pointers into pipeline_ and would dangle if a second Setup() ever
+    // reassigned pipeline_ without clearing the map first.
+    bufferedTables_.clear();
+
     stateDb_ =  std::make_shared<swss::DBConnector>(BMP_DB_NAME, 0, false);
     separator_ = swss::SonicDBConfig::getSeparator(BMP_DB_NAME);
 

--- a/Server/src/RedisManager.cpp
+++ b/Server/src/RedisManager.cpp
@@ -155,8 +155,17 @@ void RedisManager::FlushBMPTables() {
  */
 void RedisManager::ExitRedisManager() {
     // Best-effort: drain anything still buffered so we don't lose state
-    // updates that have already been observed by openbmpd.
-    FlushBMPTables();
+    // updates that have already been observed by openbmpd. This runs from
+    // ~MsgBusImpl_redis, so we must not let a redis I/O error escape into
+    // the destructor chain - mirror swss::RedisPipeline's own dtor
+    // pattern and swallow exceptions here.
+    try {
+        FlushBMPTables();
+    } catch (const std::exception& e) {
+        LOG_INFO("RedisManager ExitRedisManager flush failed: %s", e.what());
+    } catch (...) {
+        LOG_INFO("RedisManager ExitRedisManager flush failed with unknown exception");
+    }
     exit_ = true;
 }
 
@@ -197,6 +206,12 @@ bool RedisManager::InitBMPConfig() {
  * \param [in] table    Reference to table name BGP_NEIGHBOR_TABLE/BGP_RIB_OUT_TABLE/BGP_RIB_IN_TABLE
  */
 void RedisManager::ResetBMPTable(const std::string & table) {
+
+    // Drain the pipeline before reading the current key set: getKeys() runs
+    // on stateDb_'s connection and would otherwise miss any SETs that are
+    // still buffered in pipeline_ (which uses an independent connection),
+    // leaving stale entries in redis after the reset completes.
+    FlushBMPTables();
 
     std::unique_ptr<swss::Table> stateBMPTable = std::make_unique<swss::Table>(stateDb_.get(), table);
     std::vector<std::string> keys;

--- a/Server/src/RedisManager.h
+++ b/Server/src/RedisManager.h
@@ -13,11 +13,14 @@
 #include <swss/dbconnector.h>
 #include <swss/table.h>
 #include <swss/configdb.h>
+#include <swss/redispipeline.h>
 
 #include <string>
 #include <list>
 #include <map>
+#include <memory>
 #include <mutex>
+#include <unordered_map>
 #include <unordered_set>
 #include <functional>
 #include <vector>
@@ -119,6 +122,16 @@ public:
     bool RemoveEntityFromBMPTable(const std::vector<std::string>& keys);
 
     /**
+     * FlushBMPTables - flush any pending buffered HSET operations on the
+     * pipelined per-table writers. Should be called at natural batch
+     * boundaries (e.g. after a full BMP UPDATE message is processed) so
+     * that buffered redis writes are actually delivered.
+     *
+     * \param [in] N/A
+     */
+    void FlushBMPTables();
+
+    /**
      * Get Key separator for deletion
      *
      * \param [in] N/A
@@ -126,7 +139,16 @@ public:
     std::string GetKeySeparator();
 
 private:
+    /**
+     * Lookup (or lazily create) a buffered swss::Table writer for the
+     * given table name, backed by pipeline_. Returns nullptr if the table
+     * is not in enabledTables_.
+     */
+    swss::Table* GetOrCreateBufferedTable(const std::string& table);
+
     std::shared_ptr<swss::DBConnector> stateDb_;
+    std::shared_ptr<swss::RedisPipeline> pipeline_;
+    std::unordered_map<std::string, std::unique_ptr<swss::Table>> bufferedTables_;
     std::string separator_;
     Logger *logger;
     std::unordered_set<std::string> enabledTables_;

--- a/Server/src/redis/MsgBusImpl_redis.cpp
+++ b/Server/src/redis/MsgBusImpl_redis.cpp
@@ -96,6 +96,10 @@ void MsgBusImpl_redis::update_Peer(obj_bgp_peer &peer, obj_peer_up_event *up, ob
     }
 
     redisMgr_.WriteBMPTable(BMP_TABLE_NEI, keys, fieldValues);
+    // Peer state transitions are infrequent and BMP consumers expect to
+    // see them immediately; flush right away rather than waiting for the
+    // pipeline buffer to fill.
+    redisMgr_.FlushBMPTables();
 }
 
 
@@ -183,7 +187,17 @@ void MsgBusImpl_redis::update_unicastPrefix(obj_bgp_peer &peer, vector<obj_rib> 
     }
 
     if (!del_keys.empty()) {
+        // RemoveEntityFromBMPTable already flushes any buffered SETs
+        // before issuing the DEL, so SET-then-DEL ordering on the same
+        // key is preserved.
         redisMgr_.RemoveEntityFromBMPTable(del_keys);
+    } else {
+        // ADD path accumulated buffered set() calls across all rib[i]
+        // entries above; emit them in a single pipelined round-trip
+        // instead of one HSET-per-route. Without this flush the buffered
+        // updates would only be sent when the pipeline buffer fills,
+        // which can delay BMP state visibility for slow producers.
+        redisMgr_.FlushBMPTables();
     }
 }
 


### PR DESCRIPTION
## What this PR does

Profiling `test_sessions_flapping[500]` on a SONiC DUT showed that `openbmpd` consumed ~15% of OnCPU during BGP convergence, with the entire stack dominated by:

`openbmpd -> libswsscommon -> libhiredis -> libc -> vmlinux syscall`

Root cause is in `Server/src/RedisManager.cpp::WriteBMPTable`: every BMP route update goes through a freshly constructed `swss::Table` and a **synchronous** `HSET` round-trip to redis. With ~500 BGP sessions flapping simultaneously and thousands of routes per session, this becomes millions of small synchronous redis round-trips on the BMP message processing thread during a single convergence window.

This PR replaces the per-call `swss::Table` + synchronous `set()` with a shared `swss::RedisPipeline` and **buffered** `swss::Table` writers cached per table name. Flush points are chosen at natural batch boundaries (end of each BMP UPDATE message; immediately for peer state transitions).

## Changes

### `Server/src/RedisManager.{h,cpp}`

* New shared `swss::RedisPipeline pipeline_` (size 1024) built in `Setup()`, bound to `stateDb_`.
* New `std::unordered_map<std::string, std::unique_ptr<swss::Table>> bufferedTables_` caches one buffered `Table` per enabled table name (`BGP_NEIGHBOR_TABLE` / `BGP_RIB_IN_TABLE` / `BGP_RIB_OUT_TABLE`).
* `WriteBMPTable()` calls `GetOrCreateBufferedTable()` instead of constructing a fresh `Table`; each `set()` enqueues into the pipeline buffer rather than triggering a synchronous HSET.
* New `FlushBMPTables()` drains the pipeline; callers invoke it at message boundaries.
* `RemoveEntityFromBMPTable()` flushes the pipeline before issuing the batched `DEL`, preserving SET-then-DEL ordering on the same key.
* `ExitRedisManager()` drains the pipeline so updates already observed by openbmpd are not lost at shutdown.

### `Server/src/redis/MsgBusImpl_redis.cpp`

* `update_unicastPrefix()`: after the per-rib-entry loop, call `FlushBMPTables()` once on the ADD path; the DEL path is unchanged because `RemoveEntityFromBMPTable()` flushes internally.
* `update_Peer()`: flush immediately after the single neighbor write, because peer up/down events are infrequent and consumers expect them to be visible right away.

## Why this is safe

| Concern | Mitigation |
|---|---|
| **Thread safety** | `MsgBusImpl_redis` (and therefore `RedisManager` + its pipeline) is constructed per BMP client connection in openbmpd's per-client-thread model. The shared pipeline never crosses threads, so no new locking is needed. |
| **Visibility delay** | Writes are flushed at every BMP UPDATE boundary, every peer event, every DEL, and on shutdown. The pipeline also auto-flushes when its 1024-entry buffer fills. Net effect: BMP state visibility is bounded by the duration of a single BMP UPDATE message, which is already a natural granularity for BMP consumers. |
| **CONFIG_DB gating** | `enabledTables_` is still consulted before any `Table` object is touched; disabled tables short-circuit early just as before. |
| **DEL ordering** | `RemoveEntityFromBMPTable()` now flushes the pipeline before issuing the batched `DEL` on the same connection, so a SET followed by a DEL of the same key cannot be reordered. |
| **ResetAllTables / ResetBMPTable** | These existing reset paths operate directly on `stateDb_` (not via the pipeline) and are only triggered on FRR reconnect, which is rare; they remain functionally unchanged. |

## Expected impact

For a BMP UPDATE carrying *N* route entries, redis round-trips drop from *N* synchronous HSETs to ~1 pipelined batch. In the `test_sessions_flapping[500]` profile this is the change targeting the ~15% openbmpd OnCPU share; combined with a separate effort to tighten the default of `BMP|table|bgp_rib_out_table` for deployments that do not consume the outbound RIB, that share is expected to drop substantially.

## Test plan

* Build openbmpd against current `swss-common` (which already provides `swss::RedisPipeline` and the buffered `swss::Table` ctor used here).
* Run an existing BMP scale scenario; verify `BGP_NEIGHBOR_TABLE` / `BGP_RIB_IN_TABLE` / `BGP_RIB_OUT_TABLE` entries appear in `BMP_STATE_DB` exactly as before (same keys, same fields), and that DEL events still remove the corresponding entries.
* Verify that on FRR disconnect + reconnect, `ResetAllTables` still clears state.
* Re-profile `test_sessions_flapping[500]`; expect the `openbmpd -> libswsscommon -> libhiredis` stack to shrink substantially.