### PR TITLE
azure-pipelines: migrate libyang1 deb install to libyang3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,7 +118,7 @@ jobs:
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/$(BUILD_BRANCH)'
         patterns: |
-            target/debs/bookworm/libyang*.deb
+            target/debs/bookworm/libyang3_*.deb
             target/debs/bookworm/libnl*.deb
             target/python-wheels/bookworm/sonic_yang_models*.whl
       displayName: "Download bookworm debs"
@@ -131,7 +131,7 @@ jobs:
         sudo dpkg -i ../target/debs/bookworm/libnl-route-3-200_*.deb
         sudo dpkg -i ../target/debs/bookworm/libnl-nf-3-200_*.deb
         # LIBYANG
-        sudo dpkg -i ../target/debs/bookworm/libyang*1.0.73*.deb
+        sudo dpkg -i ../target/debs/bookworm/libyang3_*.deb
         # SONIC YANGS
         set -ex
         sudo pip3 install ../target/python-wheels/bookworm/sonic_yang_models-1.0-py3-none-any.whl


### PR DESCRIPTION
#### Why I did it

`sonic-buildimage` no longer builds the libyang1 debs (`libyang_1.0.73`, `libyang-cpp`, `python3-yang`); it now builds only libyang3. The `sonic-bmp` Azure pipeline installed the removed `libyang*1.0.73*.deb` from the downloaded `sonic-buildimage` build assets, so the dependency install step would fail to find/install that file.

Part of sonic-net/sonic-buildimage#22385.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Updated the `Install libswsscommon dependencies` step in `azure-pipelines.yml` to install the libyang3 runtime deb using a versionless glob (`libyang3_*.deb`) instead of the removed `libyang*1.0.73*.deb`. The existing download pattern `target/debs/bookworm/libyang*.deb` already matches the libyang3 artifacts, so no change was needed there. Only the runtime library is required here (the prebuilt `sonic-swss-common` deb links libyang at runtime), so no `-dev`/headers package is installed.

#### How to verify it

Run the Azure pipeline; the `Download bookworm debs` step pulls the libyang3 deb via the existing glob, and the `Install libswsscommon dependencies` step installs `libyang3_*.deb` successfully.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes when they are clean cherry-picks.
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Add it nightly build branch here)

- [ ] 202305

#### Description for the changelog

azure-pipelines: migrate libyang1 deb install to libyang3

#### Link to config_db schema for YANG module changes

<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to a `doc` directory.
-->

#### A picture of a cute animal (not mandatory but encouraged)
