### PR TITLE
debian/rules: add full OpenSSF compiler hardening baseline

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,8 @@
 #!/usr/bin/make -f
 
+# Upgrade FORTIFY_SOURCE to level 3 (dpkg default is =2).
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CPPFLAGS_MAINT_APPEND = -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
+
 %:
 	dh $@


### PR DESCRIPTION
#### Why I did it

Enable compiler and linker hardening flags aligned with the [OpenSSF Compiler Options Hardening Guide for C and C++](https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html).

##### Work item tracking
- Microsoft ADO:

#### How I did it

Add to `debian/rules`:
- `hardening=+all,+bindnow`: full RELRO, stack-protector-strong, format checks, PIE
- `FORTIFY_SOURCE=3`: upgraded from dpkg default of 2
- `_GLIBCXX_ASSERTIONS`: C++ stdlib bounds checking
- `-fstack-clash-protection`: stack clash mitigation
- `-fcf-protection=full` (amd64) / `-mbranch-protection=standard` (arm64): CFI
- Production safety flags: `-fno-delete-null-pointer-checks`, `-fno-strict-overflow`, `-fno-strict-aliasing`, `-ftrivial-auto-var-init=zero` (GCC >= 12 only)
- Linker: `-Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,--as-needed`

#### How to verify it

CI build passes. Verify with `objdump -d` or `checksec` on produced binaries.

#### Description for the changelog

enable OpenSSF compiler hardening baseline

#### Link to config_db schema for YANG changes
N/A