### PR TITLE
azure-pipelines: use new sonic-slave image tag format

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-22.04'
   container:
-    image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest
+    image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:$(BUILD_BRANCH)-${{ parameters.arch }}
 
   steps:
     - script: |


### PR DESCRIPTION
#### Why I did it

The sonic-slave image naming strategy was updated by sonic-net/sonic-buildimage#24922. Architecture is now part of the image tag rather than the image name. The existing `latest` tag may no longer select the intended branch-specific build environment.

#### How I did it

Updated the Azure Pipeline container image tag from `latest` to `$(BUILD_BRANCH)-${{ parameters.arch }}`.

#### How to verify it

Confirm the Azure Pipeline starts successfully using the branch-specific amd64 sonic-slave image.